### PR TITLE
Fix compile errors on archlinux

### DIFF
--- a/src/server/kernel/wbackend.cpp
+++ b/src/server/kernel/wbackend.cpp
@@ -28,10 +28,10 @@
 #include <QDebug>
 
 extern "C" {
-#define static
 #include <wlr/backend.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_input_device.h>
+#define static
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/render/wlr_renderer.h>
 #undef static

--- a/src/server/kernel/wcursor.cpp
+++ b/src/server/kernel/wcursor.cpp
@@ -33,11 +33,9 @@
 #include <QDebug>
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_pointer.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/winputdevice.cpp
+++ b/src/server/kernel/winputdevice.cpp
@@ -24,10 +24,8 @@
 #include <QDebug>
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/woutput.cpp
+++ b/src/server/kernel/woutput.cpp
@@ -30,15 +30,15 @@
 #include "utils/wtools.h"
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/backend.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/render/egl.h>
+#define static
 #include <wlr/render/gles2.h>
-#include <wlr/render/pixman.h>
 #undef static
+#include <wlr/render/pixman.h>
 }
 
 #include <QSurface>

--- a/src/server/kernel/woutputlayout.cpp
+++ b/src/server/kernel/woutputlayout.cpp
@@ -28,9 +28,7 @@
 #include <QDebug>
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_output_layout.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/wseat.cpp
+++ b/src/server/kernel/wseat.cpp
@@ -33,12 +33,10 @@
 #include <private/qxkbcommon_p.h>
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xdg_shell.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/wserver.cpp
+++ b/src/server/kernel/wserver.cpp
@@ -38,9 +38,10 @@
 #include <private/qthread_p.h>
 
 extern "C" {
-#define static
 #include <wlr/backend.h>
+#define static
 #include <wlr/render/wlr_renderer.h>
+#undef static
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -48,7 +49,6 @@ extern "C" {
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -28,10 +28,8 @@
 #include <QDebug>
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/edges.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/wtexture.cpp
+++ b/src/server/kernel/wtexture.cpp
@@ -22,11 +22,11 @@
 #include "utils/wtools.h"
 
 extern "C" {
-#define static
 #include <wlr/render/wlr_texture.h>
+#define static
 #include <wlr/render/gles2.h>
-#include <wlr/render/pixman.h>
 #undef static
+#include <wlr/render/pixman.h>
 }
 
 #include <private/qsgplaintexture_p.h>

--- a/src/server/kernel/wxcursormanager.cpp
+++ b/src/server/kernel/wxcursormanager.cpp
@@ -22,9 +22,7 @@
 
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_xcursor_manager.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/wxdgshell.cpp
+++ b/src/server/kernel/wxdgshell.cpp
@@ -26,10 +26,8 @@
 
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/edges.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/server/kernel/wxdgsurface.cpp
+++ b/src/server/kernel/wxdgsurface.cpp
@@ -25,9 +25,7 @@
 #include <QDebug>
 
 extern "C" {
-#define static
 #include <wlr/types/wlr_xdg_shell.h>
-#undef static
 }
 
 WAYLIB_SERVER_BEGIN_NAMESPACE


### PR DESCRIPTION
Only overwrite the definition of the static keyword when necessary, and
only need to do this if you include the wlroots header file that uses
static.