### PR TITLE
Support auto create *.cmake/*.pc files on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,5 +14,8 @@ set(CMAKE_AUTOUIC ON)
 # Use Qt5
 set(QT_VERSION_MAJOR 5)
 
+# For Unix/Linux
+include(GNUInstallDirs)
+
 add_subdirectory(src)
 add_subdirectory(examples)

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -1,0 +1,28 @@
+function(add_cmake_module name library include_dir)
+    include(CMakePackageConfigHelpers)
+    configure_file(${PROJECT_SOURCE_DIR}/src/cmake/CMakeConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${name}Config.cmake
+    )
+    write_basic_package_version_file(
+      ${CMAKE_CURRENT_BINARY_DIR}/${name}ConfigVersion.cmake
+      VERSION ${PROJECT_VERSION}
+      COMPATIBILITY AnyNewerVersion
+    )
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${name}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${name}ConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${name}
+    )
+endfunction()
+
+function(add_pkgconfig_module name library include_dir depends)
+    # For cmake
+    include(CMakePackageConfigHelpers)
+    configure_file(${PROJECT_SOURCE_DIR}/src/cmake/pkgconfig.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${name}.pc
+    )
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${name}.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+endfunction()

--- a/debian/libwaylib-dev.install
+++ b/debian/libwaylib-dev.install
@@ -1,2 +1,4 @@
 usr/lib/*/lib*.so
 usr/include
+usr/lib/*/pkgconfig
+usr/lib/*/cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,8 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+install(FILES
+    cmake/WaylibConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Waylib
+)
+
 add_subdirectory(server)

--- a/src/cmake/CMakeConfig.cmake.in
+++ b/src/cmake/CMakeConfig.cmake.in
@@ -1,0 +1,3 @@
+set(${name}_INCLUDE_DIR ${include_dir})
+set(${name}_LIBRARIES ${library})
+include_directories(${include_dir})

--- a/src/cmake/WaylibConfig.cmake
+++ b/src/cmake/WaylibConfig.cmake
@@ -1,0 +1,3 @@
+foreach(module ${Waylib_FIND_COMPONENTS})
+    find_package(Waylib${module})
+endforeach()

--- a/src/cmake/pkgconfig.pc.in
+++ b/src/cmake/pkgconfig.pc.in
@@ -1,0 +1,11 @@
+prefix=${CMAKE_INSTALL_PREFIX}
+exec_prefix=${CMAKE_INSTALL_PREFIX}
+libdir=${CMAKE_INSTALL_FULL_LIBDIR}
+includedir=${include_dir}
+
+Name: ${name}
+Description:
+Version: ${CMAKE_PROJECT_VERSION}
+Requires: ${depends}
+Libs: -l${library}
+Cflags: -I${include_dir}

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -144,3 +144,9 @@ install(TARGETS ${TARGET}
         COMPONENT Development
         DESTINATION include/${TARGET}
 )
+
+include(${PROJECT_SOURCE_DIR}/cmake/Helpers.cmake)
+add_cmake_module(WaylibServer ${TARGET} ${CMAKE_INSTALL_FULL_INCLUDEDIR}/${TARGET})
+add_pkgconfig_module(${TARGET} ${TARGET} ${CMAKE_INSTALL_FULL_INCLUDEDIR}/${TARGET}
+    "wlroots Qt${QT_VERSION_MAJOR}Gui Qt${QT_VERSION_MAJOR}Quick"
+)


### PR DESCRIPTION
Support use the waylib libraries in cmake/qmake/pkgconfig build system
on other projects. Not create the pri file for qmake, can use the
pkgconfig in qmake.

Resolves: #3