### PR TITLE
Fix crash on map a popup surface

### DIFF
--- a/examples/tinywl/CMakeLists.txt
+++ b/examples/tinywl/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt5 COMPONENTS Quick QuickControls2 REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Quick QuickControls2 REQUIRED)
 
 set(SOURCES main.cpp)
 qt5_add_resources(SOURCES qml.qrc)
@@ -9,6 +9,7 @@ add_executable(tinywl
 
 target_link_libraries(tinywl
     PRIVATE
+    Qt5::Widgets
     Qt5::Quick
     Qt5::QuickControls2
     waylibserver

--- a/examples/tinywl/Window.qml
+++ b/examples/tinywl/Window.qml
@@ -1,5 +1,6 @@
 import QtQuick.Controls 2.5
 import QtQuick 2.0
+import Qt.labs.platform 1.0
 
 ApplicationWindow {
     id: window
@@ -28,7 +29,7 @@ ApplicationWindow {
 
             SequentialAnimation on rotation {
                 id: ani
-                running: true
+                running: false
                 PauseAnimation { duration: 1500 }
                 NumberAnimation { from: 0; to: 360; duration: 5000; easing.type: Easing.InOutCubic }
                 loops: Animation.Infinite
@@ -59,12 +60,27 @@ ApplicationWindow {
         font.pointSize: 20
     }
 
+    Menu {
+        id: menu
+
+        MenuItem {
+            text: "Test 1"
+        }
+
+        Menu {
+            title: "Sub Menu"
+            MenuItem {
+                text: "Test 2"
+            }
+        }
+    }
+
     Button {
-        text: "Resize"
+        id: menuButton
+        text: "Menu"
         anchors.centerIn: parent
         onClicked: {
-            window.width += 50;
-            window.height += 50;
+            menu.open(menuButton)
         }
     }
 }

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -42,6 +42,7 @@
 #include <QQuickRenderControl>
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
+#include <QApplication>
 
 WAYLIB_SERVER_USE_NAMESPACE
 
@@ -150,7 +151,7 @@ int main(int argc, char *argv[]) {
 //    QGuiApplication::setAttribute(Qt::AA_UseOpenGLES);
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
     QGuiApplication::setQuitOnLastWindowClosed(false);
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     QObject::connect(&app, &QCoreApplication::aboutToQuit,
                      server.get(), &WServer::stop, Qt::DirectConnection);

--- a/src/server/kernel/private/wsurfacelayout_p.h
+++ b/src/server/kernel/private/wsurfacelayout_p.h
@@ -49,7 +49,7 @@ public:
 
     WOutputLayout *outputLayout = nullptr;
     QVector<WSurface*> surfaceList;
-    QHash<WSurface*, SurfaceData> surfaceDataMap;
+    QHash<const WSurface*, SurfaceData> surfaceDataMap;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/wsurface.cpp
+++ b/src/server/kernel/wsurface.cpp
@@ -246,13 +246,14 @@ QVector<WOutput *> WSurface::currentOutputs() const
 WOutput *WSurface::attachedOutput() const
 {
     W_DC(WSurface);
-    return d->attachedOutput.data();
+    const auto parent = parentSurface();
+    return parent ? parent->attachedOutput() : d->attachedOutput.data();
 }
 
 QPointF WSurface::position() const
 {
     W_DC(WSurface);
-    return d->layout ? d->layout->position(const_cast<WSurface*>(this)) : QPointF();
+    return d->layout ? d->layout->position(this) : QPointF();
 }
 
 QPointF WSurface::effectivePosition() const

--- a/src/server/kernel/wsurfacelayout.cpp
+++ b/src/server/kernel/wsurfacelayout.cpp
@@ -174,7 +174,7 @@ void WSurfaceLayout::requestUnmaximize(WSurface *surface)
     Q_UNUSED(surface)
 }
 
-QPointF WSurfaceLayout::position(WSurface *surface) const
+QPointF WSurfaceLayout::position(const WSurface *surface) const
 {
     W_DC(WSurfaceLayout);
     const auto &data = d->surfaceDataMap.value(surface);

--- a/src/server/kernel/wsurfacelayout.h
+++ b/src/server/kernel/wsurfacelayout.h
@@ -60,7 +60,7 @@ public:
     virtual void requestMaximize(WSurface *surface);
     virtual void requestUnmaximize(WSurface *surface);
 
-    virtual QPointF position(WSurface *surface) const;
+    virtual QPointF position(const WSurface *surface) const;
     virtual bool setPosition(WSurface *surface, const QPointF &pos);
     virtual WOutput *output(WSurface *surface) const;
     virtual bool setOutput(WSurface *surface, WOutput *output);


### PR DESCRIPTION
The surface's attached output should follow it's parent surface.

Add a menu widget for the tinywl example.