### PR TITLE
Fix crash on the drm platform

### DIFF
--- a/src/server/kernel/wbackend.cpp
+++ b/src/server/kernel/wbackend.cpp
@@ -90,6 +90,7 @@ public:
 void WBackendPrivate::on_new_output(void *data)
 {
     wlr_output *wlr_output = reinterpret_cast<struct wlr_output*>(data);
+    wlr_output_init_render(wlr_output, allocator, renderer);
 
     /* Some backends don't have modes. DRM+KMS does, and we need to set a mode
      * before we can use the output. The mode is a tuple of (width, height,

--- a/src/server/kernel/woutput.cpp
+++ b/src/server/kernel/woutput.cpp
@@ -765,8 +765,6 @@ void WOutputPrivate::init()
     updateProjection();
     rc->window = ensureRenderWindow();
 
-    wlr_output_init_render(this->handle, allocator(), renderer());
-
     if (wlr_renderer_is_pixman(renderer())) {
         rc->initialize(nullptr);
     } else {


### PR DESCRIPTION
The wlr_output_init_render should call on the wlr_output_commit before.