### PR TITLE
Fix the hardware cursor can't display

### DIFF
--- a/src/server/kernel/woutput.cpp
+++ b/src/server/kernel/woutput.cpp
@@ -294,8 +294,6 @@ public:
     }
 
     inline void maybeRenderCursor() {
-        if (handle->hardware_cursor)
-            return;
         contentIsDirty = true;
         maybeRender();
     }


### PR DESCRIPTION
When received the hardware cursor's 'frame' signal, must call the
wlr_output_commit to ensure the cursor plane commit to drm.