### PR TITLE
Add WOutputDamage class

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -40,6 +40,13 @@ set(KERNEL_SOURCES
     kernel/wxdgsurface.cpp
 )
 
+option(WAYLIB_DISABLE_OUTPUT_DAMAGE "Don't use the damage manager for outputs" OFF)
+if (${WAYLIB_DISABLE_OUTPUT_DAMAGE} STREQUAL "ON")
+    add_definitions(-DWAYLIB_DISABLE_OUTPUT_DAMAGE)
+else()
+    list(APPEND KERNEL_SOURCES kernel/woutputdamage.cpp)
+endif()
+
 set(QTQUICK_SOURCES
     qtquick/wsurfaceitem.cpp
     qtquick/wsurfacemanager.cpp

--- a/src/server/kernel/wcursor.cpp
+++ b/src/server/kernel/wcursor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 zkyd
+ * Copyright (C) 2021 ~ 2022 zkyd
  *
  * Author:     zkyd <zkyd@zjide.org>
  *
@@ -149,9 +149,11 @@ void WCursorPrivate::on_frame(void *)
         seat->notifyFrame(q_func());
     }
 
+#ifdef WAYLIB_DISABLE_OUTPUT_DAMAGE
     if (Q_LIKELY(lastOutput)) {
-        lastOutput->requestRenderCursor();
+        lastOutput->requestRender();
     }
+#endif
 }
 
 void WCursorPrivate::connect()

--- a/src/server/kernel/woutput.h
+++ b/src/server/kernel/woutput.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 zkyd
+ * Copyright (C) 2021 ~ 2022 zkyd
  *
  * Author:     zkyd <zkyd@zjide.org>
  *
@@ -112,7 +112,6 @@ public:
 
 public Q_SLOTS:
     void requestRender();
-    void requestRenderCursor();
 
 Q_SIGNALS:
     void positionChanged(const QPoint &pos);

--- a/src/server/kernel/woutputdamage.cpp
+++ b/src/server/kernel/woutputdamage.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 zkyd
+ *
+ * Author:     zkyd <zkyd@zjide.org>
+ *
+ * Maintainer: zkyd <zkyd@zjide.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "woutputdamage.h"
+#include "woutput.h"
+#include "wsignalconnector.h"
+#include "wtools.h"
+
+extern "C" {
+#include <wlr/types/wlr_output_damage.h>
+#include <wlr/util/box.h>
+}
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class Q_DECL_HIDDEN WOutputDamagePrivate : public WObjectPrivate
+{
+public:
+    WOutputDamagePrivate(WOutputDamage *qq)
+        : WObjectPrivate(qq) {
+        handle = wlr_output_damage_create(output()->nativeInterface<wlr_output>());
+    }
+
+    inline WOutput *output() {
+        return qobject_cast<WOutput*>(q_func()->parent());
+    }
+    void connect();
+
+    // begin slot function
+    void on_frame(void*);
+    // end slot function
+
+    W_DECLARE_PUBLIC(WOutputDamage);
+
+    wlr_output_damage *handle = nullptr;
+    WSignalConnector sc;
+};
+
+void WOutputDamagePrivate::connect()
+{
+    sc.connect(&handle->events.frame, this, &WOutputDamagePrivate::on_frame);
+    sc.connect(&handle->events.destroy, &sc, &WSignalConnector::invalidate);
+}
+
+void WOutputDamagePrivate::on_frame(void *)
+{
+    W_Q(WOutputDamage);
+    Q_EMIT q->frame();
+}
+
+WOutputDamage::WOutputDamage(WOutput *output)
+    : QObject(output)
+    , WObject(*new WOutputDamagePrivate(this))
+{
+
+}
+
+WOutputDamageHandle *WOutputDamage::handle() const
+{
+    W_DC(WOutputDamage);
+    return reinterpret_cast<WOutputDamageHandle*>(d->handle);
+}
+
+void WOutputDamage::add(const QRegion &region)
+{
+    W_D(WOutputDamage);
+    pixman_region32_t pixmanRegion;
+    WTools::toPixmanRegion(region, &pixmanRegion);
+    wlr_output_damage_add(d->handle, &pixmanRegion);
+}
+
+void WOutputDamage::addWhole()
+{
+    W_D(WOutputDamage);
+    wlr_output_damage_add_whole(d->handle);
+}
+
+void WOutputDamage::addRect(const QRect &rect)
+{
+    W_D(WOutputDamage);
+    wlr_box box;
+    WTools::toWLRBox(rect, &box);
+    wlr_output_damage_add_box(d->handle, &box);
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/kernel/woutputdamage.h
+++ b/src/server/kernel/woutputdamage.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 zkyd
+ *
+ * Author:     zkyd <zkyd@zjide.org>
+ *
+ * Maintainer: zkyd <zkyd@zjide.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wglobal.h>
+#include <wtypes.h>
+
+#include <QObject>
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WOutput;
+class WOutputDamagePrivate;
+class WOutputDamageHandle;
+class Q_DECL_EXPORT WOutputDamage : public QObject, public WObject
+{
+    Q_OBJECT;
+    W_DECLARE_PRIVATE(WOutputDamage);
+
+public:
+    explicit WOutputDamage(WOutput *output);
+
+    WOutputDamageHandle *handle() const;
+    template<typename DNativeInterface>
+    DNativeInterface *nativeInterface() const {
+        return reinterpret_cast<DNativeInterface*>(handle());
+    }
+    static WOutputDamage *fromHandle(const WOutputDamageHandle *handle);
+    template<typename DNativeInterface>
+    static inline WOutputDamage *fromHandle(const DNativeInterface *handle) {
+        return fromHandle(reinterpret_cast<const WOutputDamageHandle*>(handle));
+    }
+
+    void add(const QRegion &region);
+    void addWhole();
+    void addRect(const QRect &rect);
+
+Q_SIGNALS:
+    void frame();
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/src/server/utils/wtools.h
+++ b/src/server/utils/wtools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 zkyd
+ * Copyright (C) 2021 ~ 2022 zkyd
  *
  * Author:     zkyd <zkyd@zjide.org>
  *
@@ -23,6 +23,8 @@
 
 #include <wglobal.h>
 #include <QImage>
+#include <QRegion>
+#include <QRect>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
@@ -30,6 +32,10 @@ class WTools
 {
 public:
     static QImage fromPixmanImage(void *image, void *data = nullptr);
+    static QRegion fromPixmanRegion(void *region);
+    static void toPixmanRegion(const QRegion &region, void *pixmanRegion);
+    static QRect fromWLRBox(void *box);
+    static void toWLRBox(const QRect &rect, void *box);
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
Use wlr_output_damage for wlr_output. Because can't get the damage
regions from QQuickRenderControl, always to use WOutputDamage::addWhole
now.

fix #30 